### PR TITLE
fix: production deploy config

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -110,7 +110,14 @@ jobs:
           work-dir: infra
           config-map: |
             {
-              "gotloop:imageTag": { "value": "${{ steps.tag.outputs.sha }}" }
+              "gotloop:imageTag": { "value": "${{ steps.tag.outputs.sha }}" },
+              "gotloop:environment": { "value": "production" },
+              "gotloop:domain": { "value": "gotloop.io" },
+              "gotloop:cloudSqlTier": { "value": "db-custom-1-3840" },
+              "gotloop:minInstances": { "value": "1" },
+              "gotloop:maxInstances": { "value": "10" },
+              "gcp:project": { "value": "gotloop" },
+              "gcp:region": { "value": "europe-west9" }
             }
         env:
           PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}

--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -6,4 +6,3 @@ config:
   gotloop:cloudSqlTier: db-custom-1-3840
   gotloop:minInstances: "1"
   gotloop:maxInstances: "10"
-encryptionsalt: v1:nV1HrpDwtqM=:v1:srpLr9pUsMMDAJsC:VrkD5wFCE39m59oiypSZhnECrcRj5Q==


### PR DESCRIPTION
## Summary
- Remove stale `encryptionsalt` from `Pulumi.production.yaml` that caused passphrase mismatch
- Pass all required config values (`environment`, `domain`, `cloudSqlTier`, etc.) via `config-map` in the production workflow

## Context
First production deploy failed with `incorrect passphrase` because the stack config had an encryption salt from local initialization that doesn't match the CI passphrase.

## Test plan
- [ ] Merge to main and verify production Pulumi step passes the passphrase check
- [ ] Verify all config values are correctly set on the production stack