### PR TITLE
fix: adm Cloud Run memory 512Mi minimum

### DIFF
--- a/infra/src/cloud-run.ts
+++ b/infra/src/cloud-run.ts
@@ -162,7 +162,7 @@ export const admService = isProduction
             resources: {
               limits: {
                 cpu: "1",
-                memory: "256Mi",
+                memory: "512Mi",
               },
             },
           },


### PR DESCRIPTION
## Summary
- Set adm service memory to 512Mi (was 256Mi)
- Cloud Run requires >= 512Mi with 1 CPU always allocated

Same fix we applied to api/www but was missed on the adm (production-only) service.